### PR TITLE
make gitprovider enum case insensitve

### DIFF
--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -1035,6 +1035,13 @@ class GitProvider(Enum):
     GIT_LAB = 'gitLab'
     GIT_LAB_ENTERPRISE_EDITION = 'gitLabEnterpriseEdition'
 
+    # [PROD-2302] The API treats this enum as case insensitive and the strictness here was causing failures
+    @classmethod
+    def _missing_(cls, value):
+        for member in cls:
+            if member.value.lower() == value.lower():
+                return member
+
 
 @dataclass
 class GitSnapshot:


### PR DESCRIPTION
See jira ticket here: https://synccomputing.atlassian.net/jira/software/c/projects/PROD/boards/16?assignee=63287f6b2eaaa5dcfa10eb96&selectedIssue=PROD-2302

Modified the GitProvider enum to be case insensitive.
